### PR TITLE
Add 20 seconds of clock leeway to JWT validation

### DIFF
--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -292,6 +292,7 @@ class LtiMessageLaunch {
 
         // Validate JWT signature
         try {
+            JWT::$leeway = 20; // $leeway in seconds
             JWT::decode($this->request['id_token'], $public_key['key'], array('RS256'));
         } catch(\Exception $e) {
             var_dump($e);


### PR DESCRIPTION
The Firebase docs say don't go over a few minutes in leeway, so 20 seconds should be fine.  The default is 1 second, I believe.  The Blackboard servers have clocks that are not matched to the VidGrid clock, a lot of customers are running into it.